### PR TITLE
Prevent crash when app->menus is NULL

### DIFF
--- a/menu-cache-gen/menu-compose.c
+++ b/menu-cache-gen/menu-compose.c
@@ -861,7 +861,7 @@ static gint _stage2(MenuMenu *menu, gboolean with_hidden)
         next = child->next;
         switch (app->type) {
         case MENU_CACHE_TYPE_APP: /* Menu App */
-            if (menu->layout.only_unallocated && app->menus->next != NULL)
+            if (menu->layout.only_unallocated && app->menus != NULL && app->menus->next != NULL)
             {
                 VDBG("removing from %s as only_unallocated %s",menu->name,app->id);
                 /* it is more than in one menu */


### PR DESCRIPTION
menu-cache-gen crashes when using lxde-applications.menu as input, see pastebin for test file.

http://pastebin.com/EuH9sdZ0

Although I am not sure what stops working when adding another check, at least I know it does do more, than when it crashed. :)

This patch just adds a check for the existence of the object, before using it (which prevents the crash).