### PR TITLE
Fix potential fd leaks

### DIFF
--- a/libmenu-cache/menu-cache.c
+++ b/libmenu-cache/menu-cache.c
@@ -1719,6 +1719,9 @@ retry:
         G_UNLOCK(connect);
         return FALSE;
     }
+
+    fcntl (fd, F_SETFD, FD_CLOEXEC);
+
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
 

--- a/menu-cache-daemon/menu-cached.c
+++ b/menu-cache-daemon/menu-cached.c
@@ -492,6 +492,8 @@ static int create_socket(struct sockaddr_un *addr)
         return -1;
     }
 
+    fcntl (fd, F_SETFD, FD_CLOEXEC);
+
     /* remove previous socket file */
     if (unlink(addr->sun_path) < 0) {
         if (errno != ENOENT)
@@ -737,6 +739,8 @@ static gboolean on_new_conn_incoming(GIOChannel* ch, GIOCondition cond, gpointer
         DEBUG("accept error");
         return TRUE;
     }
+
+    fcntl (client, F_SETFD, FD_CLOEXEC);
 
     child = g_io_channel_unix_new(client);
     g_io_channel_set_close_on_unref( child, TRUE );

--- a/menu-cache-daemon/menu-cached.c
+++ b/menu-cache-daemon/menu-cached.c
@@ -818,12 +818,12 @@ int main(int argc, char** argv)
         g_error("can't change directory to /");
     }
 
+    /* don't hold open fd opened besides server socket and std{in,out,err} */
     open_max = sysconf (_SC_OPEN_MAX);
-    for (i = 0; i < open_max; i++)
+    for (i = 3; i < open_max; i++)
     {
-        /* don't hold open fd opened besides server socket */
         if (i != server_fd)
-            fcntl (i, F_SETFD, FD_CLOEXEC);
+            close (i);
     }
 
     /* /dev/null for stdin, stdout, stderr */


### PR DESCRIPTION
Actually close all inherited fds on daemonization and avoid leaking any sockets opened by library/daemon into children processes.
Compile-tested only for now.