### PR TITLE
Support gcc10 compilation

### DIFF
--- a/menu-cache-gen/menu-tags.h
+++ b/menu-cache-gen/menu-tags.h
@@ -22,38 +22,17 @@
 #include <libfm/fm-extra.h>
 #include <menu-cache.h>
 
-FmXmlFileTag menuTag_Menu;
-FmXmlFileTag menuTag_AppDir;
-FmXmlFileTag menuTag_DefaultAppDirs;
-FmXmlFileTag menuTag_DirectoryDir;
-FmXmlFileTag menuTag_DefaultDirectoryDirs;
-FmXmlFileTag menuTag_Include;
-FmXmlFileTag menuTag_Exclude;
-FmXmlFileTag menuTag_Filename;
-FmXmlFileTag menuTag_Or;
-FmXmlFileTag menuTag_And;
-FmXmlFileTag menuTag_Not;
-FmXmlFileTag menuTag_Category;
-FmXmlFileTag menuTag_MergeFile;
-FmXmlFileTag menuTag_MergeDir;
-FmXmlFileTag menuTag_DefaultMergeDirs;
-FmXmlFileTag menuTag_Directory;
-FmXmlFileTag menuTag_Name;
-FmXmlFileTag menuTag_Deleted;
-FmXmlFileTag menuTag_NotDeleted;
-FmXmlFileTag menuTag_OnlyUnallocated;
-FmXmlFileTag menuTag_NotOnlyUnallocated;
-FmXmlFileTag menuTag_All;
-FmXmlFileTag menuTag_LegacyDir;
-FmXmlFileTag menuTag_KDELegacyDirs;
-FmXmlFileTag menuTag_Move;
-FmXmlFileTag menuTag_Old;
-FmXmlFileTag menuTag_New;
-FmXmlFileTag menuTag_Layout;
-FmXmlFileTag menuTag_DefaultLayout;
-FmXmlFileTag menuTag_Menuname;
-FmXmlFileTag menuTag_Separator;
-FmXmlFileTag menuTag_Merge;
+extern FmXmlFileTag menuTag_AppDir;
+extern FmXmlFileTag menuTag_DirectoryDir;
+extern FmXmlFileTag menuTag_Include;
+extern FmXmlFileTag menuTag_Exclude;
+extern FmXmlFileTag menuTag_Filename;
+extern FmXmlFileTag menuTag_Or;
+extern FmXmlFileTag menuTag_And;
+extern FmXmlFileTag menuTag_Not;
+extern FmXmlFileTag menuTag_Category;
+extern FmXmlFileTag menuTag_All;
+extern FmXmlFileTag menuTag_LegacyDir;
 
 typedef enum {
     MERGE_NONE, /* starting value */
@@ -152,19 +131,19 @@ typedef struct {
 } MenuRule;
 
 /* requested language(s) */
-char **languages;
+extern char **languages;
 
 /* list of menu files to monitor */
-GSList *MenuFiles;
+extern GSList *MenuFiles;
 
 /* list of menu dirs to monitor */
-GSList *MenuDirs;
+extern GSList *MenuDirs;
 
 /* list of available app dirs */
-GSList *AppDirs;
+extern GSList *AppDirs;
 
 /* list of available dir dirs */
-GSList *DirDirs;
+extern GSList *DirDirs;
 
 /* parse and merge menu files */
 MenuMenu *get_merged_menu(const char *file, FmXmlFile **xmlfile, GError **error);
@@ -177,7 +156,7 @@ gboolean save_menu_cache(MenuMenu *layout, const char *menuname, const char *fil
 void _free_layout_items(GList *data);
 
 /* verbosity level */
-gint verbose;
+extern gint verbose;
 
 #define DBG if (verbose) g_debug
 #define VDBG if (verbose > 1) g_debug


### PR DESCRIPTION
gcc10 now defaults to -fno-common, and with gcc10 menu-cache compilation fails like

/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:167: multiple definition of `DirDirs'; main.o:menu-cache-gen/menu-tags.h:167: first defined here
/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:164: multiple definition of `AppDirs'; main.o:menu-cache-gen/menu-tags.h:164: first defined here
/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:52: multiple definition of `menuTag_Layout'; main.o:menu-cache-gen/menu-tags.h:52: first defined here
....

This patch fixes compilation with gcc10: properly declaring variables in header with "extern", and also removing some unneeded variables in header files.